### PR TITLE
feat: add unified getStorefront api

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,6 @@ All Android-only functions must end with `Android`:
 - `acknowledgePurchaseAndroid`
 - `consumePurchaseAndroid`
 - `getPackageNameAndroid`
-- `getStorefrontAndroid`
 
 #### 3. Cross-Platform Functions (No suffix)
 
@@ -59,6 +58,7 @@ Functions available on both platforms have no suffix:
 - `getActiveSubscriptions` - Get active subscriptions
 - `hasActiveSubscriptions` - Check subscription status
 - `deepLinkToSubscriptions` - Open subscription management
+- `getStorefront` - Get storefront metadata
 
 ### Naming Rules
 
@@ -88,6 +88,7 @@ Functions available on both platforms have no suffix:
 
 - `buy-promoted-product-ios` → Use `requestPurchaseOnPromotedProductIOS`
 - `requestProducts` → Use `fetchProducts`
+- `get-storefront-ios` → Use `getStorefront`
 
 ## Modal Pattern with Preact Signals
 

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -118,7 +118,6 @@ const apiData: ApiItem[] = [
     returns: 'ReceiptValidationResult!',
     path: '/docs/apis#validate-receipt',
   },
-
   // iOS APIs
   {
     id: 'clear-transaction-ios',
@@ -133,19 +132,10 @@ const apiData: ApiItem[] = [
     id: 'get-storefront-ios',
     title: 'getStorefrontIOS',
     category: 'iOS APIs',
-    description: 'Get the current App Store storefront country code',
+    description: 'Deprecated. Use getStorefront for cross-platform data',
     parameters: '',
     returns: 'String!',
     path: '/docs/apis#get-storefront-ios',
-  },
-  {
-    id: 'get-storefront-android',
-    title: 'getStorefrontAndroid',
-    category: 'Android APIs',
-    description: 'Get Google Play storefront metadata for the active user',
-    parameters: '',
-    returns: 'StorefrontResultAndroid!',
-    path: '/docs/apis#get-storefront-android',
   },
   {
     id: 'get-promoted-product-ios',
@@ -200,6 +190,16 @@ const apiData: ApiItem[] = [
     parameters: '',
     returns: 'Void',
     path: '/docs/apis#restore-purchases',
+  },
+  // Storefront
+  {
+    id: 'get-storefront',
+    title: 'getStorefront',
+    category: 'Storefront',
+    description: 'Get storefront country code for the active user',
+    parameters: '',
+    returns: 'String!',
+    path: '/docs/apis#get-storefront',
   },
   {
     id: 'current-entitlement-ios',

--- a/src/pages/docs/apis.tsx
+++ b/src/pages/docs/apis.tsx
@@ -319,6 +319,27 @@ restorePurchases(): Future`}</CodeBlock>
             native method.
           </p>
         </blockquote>
+
+        <AnchorLink id="get-storefront" level="h3">
+          getStorefront
+        </AnchorLink>
+        <p>Get storefront metadata for the active user.</p>
+        <CodeBlock language="graphql">{`"""
+Returns: String!
+"""
+getStorefront(): Future`}</CodeBlock>
+        <p>
+          Resolves with the ISO 3166-1 alpha-2 country code for the active
+          storefront. Returns an empty string when the storefront cannot be
+          determined.
+        </p>
+        <blockquote className="info-note">
+          <p>
+            iOS uses the active StoreKit storefront. Android queries Google Play
+            Billing for the billing config and returns the same country code
+            string, falling back to an empty value when the call fails.
+          </p>
+        </blockquote>
       </section>
       <section>
         <AnchorLink id="subscription-management" level="h2">
@@ -551,9 +572,16 @@ clearTransactionIOS: Boolean!`}</CodeBlock>
                 <AnchorLink id="get-storefront-ios" level="h4">
                   getStorefrontIOS
                 </AnchorLink>
-                <p>Get the current App Store storefront country code.</p>
+                <p>
+                  <strong>Deprecated.</strong> Use{' '}
+                  <Link to="/docs/apis#get-storefront">
+                    <code>getStorefront()</code>
+                  </Link>{' '}
+                  for cross-platform storefront data.
+                </p>
                 <CodeBlock language="graphql">{`"""
-Get the current App Store storefront country code
+@deprecated(reason: "Use getStorefront")
+Returns: String!
 """
 # Future
 getStorefrontIOS: String!`}</CodeBlock>
@@ -561,6 +589,13 @@ getStorefrontIOS: String!`}</CodeBlock>
                   Returns the storefront country code (e.g., "US", "GB", "JP")
                   for the active App Store account.
                 </p>
+                <blockquote className="info-note">
+                  <p>
+                    This legacy helper will proxy to{' '}
+                    <code>getStorefront()</code> where possible and will be
+                    removed in a future release.
+                  </p>
+                </blockquote>
 
                 <AnchorLink id="get-promoted-product-ios" level="h4">
                   getPromotedProductIOS
@@ -864,33 +899,6 @@ consumePurchaseAndroid(purchaseToken: String!): Boolean!`}</CodeBlock>
                     <code>finishTransaction()</code>
                   </Link>{' '}
                   when <code>isConsumable</code> is <code>true</code>.
-                </p>
-
-                <AnchorLink id="get-storefront-android" level="h4">
-                  getStorefrontAndroid
-                </AnchorLink>
-                <p>Get Google Play storefront metadata for the active user.</p>
-                <CodeBlock language="graphql">{`extend type Query {
-  """
-  Returns: StorefrontResultAndroid!
-  """
-  # Future
-  getStorefrontAndroid: StorefrontResultAndroid!
-}
-
-type StorefrontResultAndroid {
-  countryCode: String!
-  identifier: String!
-}`}</CodeBlock>
-                <p className="type-link">
-                  See:{' '}
-                  <Link to="/docs/types#storefront-result-android">
-                    StorefrontResultAndroid
-                  </Link>
-                </p>
-                <p>
-                  Returns the Google Play storefront identifier and ISO 3166-1
-                  alpha-2 country code for the current account.
                 </p>
               </>
             ),

--- a/src/pages/docs/types.tsx
+++ b/src/pages/docs/types.tsx
@@ -675,57 +675,30 @@ type Purchase =
           Storefront
         </AnchorLink>
         <p>
-          Storefront metadata describing the marketplace associated with the
-          current user.
+          ISO 3166-1 alpha-2 storefront code returned by{' '}
+          <code>getStorefront</code>.
         </p>
-        <CodeBlock language="typescript">{`type Storefront = {
-  countryCode: string;
-  identifier: string;
-};`}</CodeBlock>
+        <CodeBlock language="typescript">{`type StorefrontCode = string;`}</CodeBlock>
         <div style={{ marginTop: '0.5rem' }}>
-          <h4 style={{ margin: 0 }}>Field Reference</h4>
+          <h4 style={{ margin: 0 }}>Usage Notes</h4>
           <ul style={{ marginTop: '0.5rem' }}>
             <li>
-              <code>countryCode</code> — ISO 3166-1 alpha-2 code (e.g., "US",
-              "KR")
+              Example values: <code>"US"</code>, <code>"KR"</code>,
+              <code>"JP"</code>
             </li>
             <li>
-              <code>identifier</code> — Storefront identifier (e.g., "USA",
-              "KOR") returned by StoreKit and other billing providers
+              May return an empty string when the storefront cannot be
+              determined.
             </li>
           </ul>
         </div>
         <blockquote className="info-note">
           <p>
-            On iOS the values are sourced from the active StoreKit storefront.
-            Other platforms return the same structure and may yield empty
-            strings when the storefront is unavailable.
+            iOS sources the value from the active StoreKit storefront. Android
+            queries Google Play Billing configuration and returns the same
+            country code string when available.
           </p>
         </blockquote>
-
-        <AnchorLink id="storefront-result-android" level="h3">
-          StorefrontResultAndroid
-        </AnchorLink>
-        <p>
-          Android-specific storefront payload returned by{' '}
-          <code>getStorefrontAndroid</code>.
-        </p>
-        <CodeBlock language="typescript">{`type StorefrontResultAndroid = {
-  countryCode: string;
-  identifier: string;
-};`}</CodeBlock>
-        <div style={{ marginTop: '0.5rem' }}>
-          <h4 style={{ margin: 0 }}>Field Reference</h4>
-          <ul style={{ marginTop: '0.5rem' }}>
-            <li>
-              <code>countryCode</code> — ISO 3166-1 alpha-2 code (e.g., "US",
-              "KR")
-            </li>
-            <li>
-              <code>identifier</code> — Google Play storefront identifier
-            </li>
-          </ul>
-        </div>
       </section>
 
       <section>


### PR DESCRIPTION
<img width="730" height="352" alt="Screenshot 2025-09-26 at 12 45 41 PM" src="https://github.com/user-attachments/assets/bf8e1506-9e53-4a1a-bd0d-13136deaeddc" />

Make `getStorefront` api unfied instead #10 and also deprecate `getStorefrontIOS` as shown in the screenshot